### PR TITLE
Add select input for utility allowance

### DIFF
--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -23,7 +23,7 @@
             <em>Answer a few questions to find out if you may be eligible and how many dollars per month you may qualify for.</em>
             <fieldset class="usa-fieldset">
               <label class="usa-label" for="state_or_territory">State:</label>
-              <select required class="usa-select" id="state_or_territory" name="state_or_territory">
+              <select class="usa-select" required id="state_or_territory" name="state_or_territory">
                 <option value>- Select -</option>
                 <!-- <option value="AL">Alabama</option>
                 <option value="AK">Alaska</option>
@@ -188,6 +188,42 @@
                    name="homeowners_insurance_and_taxes"
                    class="usa-input" />
 
+              <label class="usa-label" for="utility_allowance">
+                Which of the following describes how you pay for utilities?:
+              </label>
+              <select class="usa-select" id="utility_allowance" name="utility_allowance">
+                <option value>- Select -</option>
+                <option value="HEATING_AND_COOLING">
+                  I pay separately for heat or AC.
+                </option>
+                <option value="HEATING_AND_COOLING">
+                  I have received a LIHEAP payment of $21 to help pay for heat this year.
+                </option>
+                <option value="BASIC_LIMITED_ALLOWANCE">
+                  I pay separately for two or more of the following: electricity, cooking fuel, water, garbage, or phone.
+                </option>
+                <option value="SINGLE_UTILITY_ALLOWANCE">
+                  I pay separately for just one of the following: electricity, cooking fuel, water, garbage, or phone.
+                </option>
+                <option value="PHONE">
+                  The only utility I pay for is my phone bill.
+                </option>
+                <option value="NONE">
+                  I don't pay separately for any utilities, and I don't pay a phone bill.
+                </option>
+              </select>
+
+              <!--
+                NOTE:
+                A small number of states and territories (AK, HI, TN, VA, and the Virgin Islands)
+                do not use standard utility allowance as part of their excess shelter deduction
+                calculations. These states use a household's actual utility costs instead of
+                a standardized allowance. Since none of our early potential partnership states
+                fall in this category, I'm skipping an input for raw utility costs for now;
+                will need to add later.
+              -->
+
+              <!-- SUBMIT BUTTON -->
               <input id="prescreener-form-submit"
                      class="usa-button"
                      type="submit"


### PR DESCRIPTION
# Notes 

+ Also add note about skipping an input for raw utility costs, for now, because relatively few states use that option.