### PR TITLE
Use Python library instead of over-the-wire call

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ flask = {version="~=1.1.1", index="pypi"}
 flask-httpauth = {version="~=3.3.0", index="pypi"}
 gunicorn = {version="~=20.0.4", index="pypi"}
 requests = {version="~=2.23.0", index="pypi"}
-snap-api-prototype = {version="~=0.0.1", index="test-pypi"}
+snap-api-prototype = {version="~=0.0.3", index="test-pypi"}
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ flask-httpauth = "~=3.3.0"
 gunicorn = "~=20.0.4"
 requests = "~=2.23.0"
 snap-api-prototype = {editable = true,git = "https://github.com/18F/snap-api-prototype.git",ref = "ars/setup-setup"}
+pyyaml = "~=5.3"
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile
+++ b/Pipfile
@@ -3,17 +3,22 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
+[[source]]
+name = "test-pypi"
+url = "https://test.pypi.org/simple/"
+verify_ssl = true
+
 [dev-packages]
-python-dotenv = "~=0.11.0"
-flake8 = "~=3.7.9"
-bandit = "~=1.6.2"
+python-dotenv = {version="~=0.11.0", index="pypi"}
+flake8 = {version="~=3.7.9", index="pypi"}
+bandit = {version="~=1.6.2", index="pypi"}
 
 [packages]
-flask = "~=1.1.1"
-flask-httpauth = "~=3.3.0"
-gunicorn = "~=20.0.4"
-requests = "~=2.23.0"
-snap-api-prototype = {editable = true, git = "https://github.com/18F/snap-api-prototype.git"}
+flask = {version="~=1.1.1", index="pypi"}
+flask-httpauth = {version="~=3.3.0", index="pypi"}
+gunicorn = {version="~=20.0.4", index="pypi"}
+requests = {version="~=2.23.0", index="pypi"}
+snap-api-prototype = {version="~=0.0.1", index="test-pypi"}
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ flask = "~=1.1.1"
 flask-httpauth = "~=3.3.0"
 gunicorn = "~=20.0.4"
 requests = "~=2.23.0"
-snap-api-prototype = {editable = true,git = "https://github.com/18F/snap-api-prototype.git"}
+snap-api-prototype = {editable = true,git = "https://github.com/18F/snap-api-prototype.git",ref = "ars/setup-setup"}
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ flask = "~=1.1.1"
 flask-httpauth = "~=3.3.0"
 gunicorn = "~=20.0.4"
 requests = "~=2.23.0"
+snap-api-prototype = {editable = true,git = "https://github.com/18F/snap-api-prototype.git"}
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile
+++ b/Pipfile
@@ -13,8 +13,7 @@ flask = "~=1.1.1"
 flask-httpauth = "~=3.3.0"
 gunicorn = "~=20.0.4"
 requests = "~=2.23.0"
-snap-api-prototype = {editable = true,git = "https://github.com/18F/snap-api-prototype.git",ref = "ars/setup-setup"}
-pyyaml = "~=5.3"
+snap-api-prototype = {editable = true, git = "https://github.com/18F/snap-api-prototype.git"}
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "242dffb2cc6a83ad08b220c33732e4a2dd37dd8489262d20bdc7e8e9fa897bc1"
+            "sha256": "e098ea06a83e35705c65e3947a12211841b8b218060c128b9f14676abba9c3f5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.4.5.1"
         },
         "chardet": {
             "hashes": [
@@ -39,11 +39,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
-                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
+                "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060",
+                "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"
             ],
             "index": "pypi",
-            "version": "==1.1.1"
+            "version": "==1.1.2"
         },
         "flask-httpauth": {
             "hashes": [
@@ -77,10 +77,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
-                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "version": "==2.11.1"
+            "version": "==2.11.2"
         },
         "markupsafe": {
             "hashes": [
@@ -128,19 +128,24 @@
             "index": "pypi",
             "version": "==2.23.0"
         },
+        "snap-api-prototype": {
+            "editable": true,
+            "git": "https://github.com/18F/snap-api-prototype.git",
+            "ref": "d1f39718855feec52e087f8967905751b5faeda1"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
-                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
-            "version": "==1.25.8"
+            "version": "==1.25.9"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
-                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
+                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
+                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
             ],
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         }
     },
     "develop": {
@@ -169,17 +174,17 @@
         },
         "gitdb": {
             "hashes": [
-                "sha256:284a6a4554f954d6e737cddcff946404393e030b76a282c6640df8efd6b3da5e",
-                "sha256:598e0096bb3175a0aab3a0b5aedaa18a9a25c6707e0eca0695ba1a0baf1b2150"
+                "sha256:6f0ecd46f99bb4874e5678d628c3a198e2b4ef38daea2756a2bfd8df7dd5c1a5",
+                "sha256:ba1132c0912e8c917aa8aa990bee26315064c7b7f171ceaaac0afeb1dc656c6a"
             ],
-            "version": "==4.0.2"
+            "version": "==4.0.4"
         },
         "gitpython": {
             "hashes": [
-                "sha256:43da89427bdf18bf07f1164c6d415750693b4d50e28fc9b68de706245147b9dd",
-                "sha256:e426c3b587bd58c482f0b7fe6145ff4ac7ae6c82673fc656f489719abca6f4cb"
+                "sha256:6d4f10e2aaad1864bb0f17ec06a2c2831534140e5883c350d58b4e85189dab74",
+                "sha256:71b8dad7409efbdae4930f2b0b646aaeccce292484ffa0bc74f1195582578b3d"
             ],
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "mccabe": {
             "hashes": [
@@ -190,10 +195,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:139d2625547dbfa5fb0b81daebb39601c478c21956dc57e2e07b74450a8c506b",
-                "sha256:61aa52a0f18b71c5cc58232d2cf8f8d09cd67fcad60b742a60124cb8d6951488"
+                "sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c",
+                "sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8"
             ],
-            "version": "==5.4.4"
+            "version": "==5.4.5"
         },
         "pycodestyle": {
             "hashes": [
@@ -242,10 +247,10 @@
         },
         "smmap": {
             "hashes": [
-                "sha256:171484fe62793e3626c8b05dd752eb2ca01854b0c55a1efc0dc4210fccb65446",
-                "sha256:5fead614cf2de17ee0707a8c6a5f2aa5a2fc6c698c70993ba42f515485ffda78"
+                "sha256:52ea78b3e708d2c2b0cfe93b6fc3fbeec53db913345c26be6ed84c11ed8bebc1",
+                "sha256:b46d3fc69ba5f367df96d91f8271e8ad667a198d5a28e215a6c3d9acd133a911"
             ],
-            "version": "==3.0.1"
+            "version": "==3.0.2"
         },
         "stevedore": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f24dcb355754a320d2caba6327c8df45820e6f1d68ec202841ab8048c81cf4e"
+            "sha256": "071b1ec6ce3acef6a92b51e1ac6ad032d7e44666b481f20e22c0453de77488ce"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -120,6 +120,23 @@
             ],
             "version": "==1.1.1"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
+                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+            ],
+            "index": "pypi",
+            "version": "==5.3.1"
+        },
         "requests": {
             "hashes": [
                 "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
@@ -131,7 +148,7 @@
         "snap-api-prototype": {
             "editable": true,
             "git": "https://github.com/18F/snap-api-prototype.git",
-            "ref": "24fc68de564f9e4669807ec14fa53c37878fe0ab"
+            "ref": "e5db8c920affee22bc6c842583c7da32f0460364"
         },
         "urllib3": {
             "hashes": [
@@ -236,6 +253,7 @@
                 "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
                 "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
             ],
+            "index": "pypi",
             "version": "==5.3.1"
         },
         "six": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c837cc42d186a833db8fc5ed56eb5e7bf017012ffbd6701bfccd51e223041ea1"
+            "sha256": "26567d04ce0063b56916b63bfbd151c7aa0415189c49128c3d79003edc009d0c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,10 +37,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
         },
         "flask": {
             "hashes": [
@@ -154,11 +154,11 @@
         },
         "snap-api-prototype": {
             "hashes": [
-                "sha256:a1b3d07e2c73a2f04173b48c7e5b6e80b1b61554ecc530db913358d30410efc3",
-                "sha256:a8feb45801c68db2f98528f87b1b652bfd4f035ce18f620aae98a31bb64078f8"
+                "sha256:2c9ddb10ee69b3d70b16b3333b967f16e1323c0dde0466eaa38e12220fb46e2d",
+                "sha256:b4e14cd15e8e9730eb3ff508346d17973892b383b38f36205c0492482c7ccaa5"
             ],
             "index": "test-pypi",
-            "version": "==0.0.1"
+            "version": "==0.0.3"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "071b1ec6ce3acef6a92b51e1ac6ad032d7e44666b481f20e22c0453de77488ce"
+            "sha256": "e098ea06a83e35705c65e3947a12211841b8b218060c128b9f14676abba9c3f5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -134,7 +134,6 @@
                 "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
                 "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
             ],
-            "index": "pypi",
             "version": "==5.3.1"
         },
         "requests": {
@@ -148,7 +147,7 @@
         "snap-api-prototype": {
             "editable": true,
             "git": "https://github.com/18F/snap-api-prototype.git",
-            "ref": "e5db8c920affee22bc6c842583c7da32f0460364"
+            "ref": "e31586b00c9c9da70f0e265e1d67716b28ac1e30"
         },
         "urllib3": {
             "hashes": [
@@ -253,7 +252,6 @@
                 "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
                 "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
             ],
-            "index": "pypi",
             "version": "==5.3.1"
         },
         "six": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e098ea06a83e35705c65e3947a12211841b8b218060c128b9f14676abba9c3f5"
+            "sha256": "c837cc42d186a833db8fc5ed56eb5e7bf017012ffbd6701bfccd51e223041ea1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -11,6 +11,11 @@
             {
                 "name": "pypi",
                 "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            },
+            {
+                "name": "test-pypi",
+                "url": "https://test.pypi.org/simple/",
                 "verify_ssl": true
             }
         ]
@@ -71,6 +76,8 @@
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:72a1252c0b2cc2bcc351acf2cfe2ec0159d8578c54767d5c2aa67fd869346e55",
+                "sha256:ac4c9f590d59c36b7d2953f97fda415f2461280e5279650aafe1e593f129c4f7",
                 "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
             "version": "==1.1.0"
@@ -91,6 +98,7 @@
                 "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:30323461f382a59bcb940be0adc5e0d6be5dfc6bd1c2c5cbe2d13b96414e1619",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
@@ -145,9 +153,12 @@
             "version": "==2.23.0"
         },
         "snap-api-prototype": {
-            "editable": true,
-            "git": "https://github.com/18F/snap-api-prototype.git",
-            "ref": "e31586b00c9c9da70f0e265e1d67716b28ac1e30"
+            "hashes": [
+                "sha256:a1b3d07e2c73a2f04173b48c7e5b6e80b1b61554ecc530db913358d30410efc3",
+                "sha256:a8feb45801c68db2f98528f87b1b652bfd4f035ce18f620aae98a31bb64078f8"
+            ],
+            "index": "test-pypi",
+            "version": "==0.0.1"
         },
         "urllib3": {
             "hashes": [
@@ -167,6 +178,8 @@
     "develop": {
         "bandit": {
             "hashes": [
+                "sha256:1d0a4df27713462410157c705c3fea61c59e6e03473e65116e9b1d9659dd426e",
+                "sha256:1fc45ffddc63d5cc10c53a35cba5dd8a093567ab310c1048bcd03f32337da75a",
                 "sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952",
                 "sha256:41e75315853507aa145d62a78a2a6c5e3240fe14ee7c601459d0df9418196065"
             ],

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e098ea06a83e35705c65e3947a12211841b8b218060c128b9f14676abba9c3f5"
+            "sha256": "5f24dcb355754a320d2caba6327c8df45820e6f1d68ec202841ab8048c81cf4e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -131,7 +131,7 @@
         "snap-api-prototype": {
             "editable": true,
             "git": "https://github.com/18F/snap-api-prototype.git",
-            "ref": "d1f39718855feec52e087f8967905751b5faeda1"
+            "ref": "24fc68de564f9e4669807ec14fa53c37878fe0ab"
         },
         "urllib3": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -40,6 +40,8 @@ def create_app():
     @app.route('/calculate', methods=['POST'])
     @auth.login_required
     def forward_request_to_api():
-        request_json_data = request.get_json().to_dict()
+        request_json_data = request.get_json()
 
         return BenefitEstimate(request_json_data).calculate()
+
+    return app

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 from flask import Flask, render_template, request
 from flask_httpauth import HTTPBasicAuth
 from os import path
-from snap_financial_factors.benefit_estimate import BenefitEstimate
+from snap_financial_factors.benefit_estimate.benefit_estimate import BenefitEstimate
 
 
 def create_app():

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 from flask import Flask, render_template, request
 from flask_httpauth import HTTPBasicAuth
 from os import path
-from snap_financial_factors import BenefitEstimate
+from snap_financial_factors.benefit_estimate import BenefitEstimate
 
 
 def create_app():

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 from flask import Flask, render_template, request
 from flask_httpauth import HTTPBasicAuth
 from os import path
-from snap_financial_factors.benefit_estimate.benefit_estimate import BenefitEstimate
+from snap_financial_factors.benefit_estimate.snap_estimate_entrypoint import SnapEstimateEntrypoint
 
 
 def create_app():
@@ -42,6 +42,6 @@ def create_app():
     def forward_request_to_api():
         request_json_data = request.get_json()
 
-        return BenefitEstimate(request_json_data).calculate()
+        return SnapEstimateEntrypoint(request_json_data).calculate()
 
     return app

--- a/app.py
+++ b/app.py
@@ -39,7 +39,7 @@ def create_app():
 
     @app.route('/calculate', methods=['POST'])
     @auth.login_required
-    def forward_request_to_api():
+    def call_api():
         request_json_data = request.get_json()
 
         return SnapEstimateEntrypoint(request_json_data).calculate()

--- a/app.py
+++ b/app.py
@@ -1,8 +1,8 @@
 import os
-import requests
 from flask import Flask, render_template, request
 from flask_httpauth import HTTPBasicAuth
 from os import path
+from snap_financial_factors import BenefitEstimate
 
 
 def create_app():
@@ -40,18 +40,6 @@ def create_app():
     @app.route('/calculate', methods=['POST'])
     @auth.login_required
     def forward_request_to_api():
-        request_json_data = request.get_json()
+        request_json_data = request.get_json().to_dict()
 
-        api_username = os.environ['API_USERNAME']
-        api_password = os.environ['API_PASSWORD']
-        api_url = os.environ['API_URL']
-
-        response = requests.post(
-            api_url,
-            json=request_json_data,
-            auth=(api_username, api_password)
-        ).json()
-
-        return response
-
-    return app
+        return BenefitEstimate(request_json_data).calculate()


### PR DESCRIPTION
# Notes 

+ Switch over to using [snap-api-prototype as a Python library on test.pypi.org](https://test.pypi.org/project/snap-api-prototype/) as opposed to calling the API over the wire.
+ Gives deployer more control rather than centralizing control over eligibility in the hands of the API owner; better match with the way SNAP programs are administered.