### PR TITLE
Improve results view on mobile

### DIFF
--- a/static/prescreener.js
+++ b/static/prescreener.js
@@ -116,22 +116,24 @@ function sendData() {
 
     // Define what happens on successful data submission.
     XHR.addEventListener("load", function(event) {
-        var width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+        // Convert JSON response to HTML
+        response = JSON.parse(event.target.responseText);
+        resultHTML = responseToHTML(response);
+        var results = document.getElementById('results');
+        results.innerHTML = resultHTML;
 
         // Scroll to top if the results are displayed next to the form, as opposed to below the form.
+        // Otherwise, scroll to bottom to put results into view.
         // 640px is the tablet breakpoint in USWDS Grid system: https://designsystem.digital.gov/utilities/layout-grid/
+        var width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+
         if (width >= 640) {
             window.scrollTo(0, 0);
         } else {
-            results = document.getElementById('results');
-            results.scrollIntoView(false);
+            // Source: https://stackoverflow.com/questions/11715646/scroll-automatically-to-the-bottom-of-the-page
+            var scrollingElement = (document.scrollingElement || document.body);
+            scrollingElement.scrollTop = scrollingElement.scrollHeight;
         }
-
-        response = JSON.parse(event.target.responseText);
-        resultHTML = responseToHTML(response);
-
-        var results = document.getElementById('results');
-        results.innerHTML = resultHTML;
     });
 
     // Define what happens in case of error.

--- a/static/prescreener.js
+++ b/static/prescreener.js
@@ -70,7 +70,6 @@ function responseToHTML (response) {
           html += ('<li style="color: red;">' + error + '.</li>')
       }
 
-      window.scrollTo(0, 0);
       return html;
     }
 
@@ -93,8 +92,6 @@ function responseToHTML (response) {
         return a.sort_order - b.sort_order;
     });
 
-    console.log('eligibility_factors', eligibility_factors)
-
     for (var i = 0; i < eligibility_factors.length; i++) {
         var eligibility_factor = eligibility_factors[i];
         name = eligibility_factor.name
@@ -111,7 +108,6 @@ function responseToHTML (response) {
     }
     html += '</div>';
 
-    window.scrollTo(0, 0);
     return html;
 }
 
@@ -120,6 +116,17 @@ function sendData() {
 
     // Define what happens on successful data submission.
     XHR.addEventListener("load", function(event) {
+        var width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+
+        // Scroll to top if the results are displayed next to the form, as opposed to below the form.
+        // 640px is the tablet breakpoint in USWDS Grid system: https://designsystem.digital.gov/utilities/layout-grid/
+        if (width >= 640) {
+            window.scrollTo(0, 0);
+        } else {
+            results = document.getElementById('results');
+            results.scrollIntoView(false);
+        }
+
         response = JSON.parse(event.target.responseText);
         resultHTML = responseToHTML(response);
 


### PR DESCRIPTION
# Notes 

+ Do not auto-scroll to top of page when results are rendered on mobile; auto-scroll down instead

# Screenshot

+ Results auto-scroll into view on mobile after response comes back from API:

<img width="400" alt="Screen Shot 2020-05-07 at 11 45 50 AM" src="https://user-images.githubusercontent.com/3209501/81321772-a2bc6980-9058-11ea-8686-2666082fde44.png">
