### PR TITLE
Comment out VT option in pre-screener states dropdown

### DIFF
--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -71,7 +71,7 @@
                 <option value="TX">Texas</option>
               -->
                 <option value="UT">Utah</option>
-                <option value="VT">Vermont</option>
+                <!-- <option value="VT">Vermont</option> -->
                 <option value="VA">Virginia</option>
                 <!--
                 <option value="WA">Washington</option>


### PR DESCRIPTION
# Notes 

+ The front-end prescreener options for utilities don't match the allowances we have for VT in the API; the correct standard utility allowances (SUAs) for VT are unclear to me and it is hard to find consistent information about them online